### PR TITLE
RP2040 - Fix Watchdog::get_timeout() implementation

### DIFF
--- a/targets/TARGET_RASPBERRYPI/TARGET_RP2040/watchdog_api.c
+++ b/targets/TARGET_RASPBERRYPI/TARGET_RP2040/watchdog_api.c
@@ -4,8 +4,11 @@
 
 #if DEVICE_WATCHDOG
 
+static watchdog_config_t watchdogConfig;
+
 watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
 {
+    watchdogConfig = *config;
     // The pico watchdogs accept a maximum value of 0x7fffff
     if ( config->timeout_ms < 0x1 && config->timeout_ms > 0x7FFFFF ) {
         return WATCHDOG_STATUS_INVALID_ARGUMENT;
@@ -29,7 +32,11 @@ watchdog_status_t hal_watchdog_stop(void)
 
 uint32_t hal_watchdog_get_reload_value(void)
 {
-    return (watchdog_hw->load / 2000U);
+    uint32_t load_value = watchdogConfig.timeout_ms * 1000 * 2;
+    if (load_value > 0xffffffu) {
+        load_value = 0xffffffu;
+    }
+    return load_value;
 }
 
 watchdog_features_t hal_watchdog_get_platform_features(void)


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
`Watchdog::get_timeout()` calls function `hal_watchdog_get_reload_value()` which, in the current implementation, tries to read Watchdog LOAD register:
`return (watchdog_hw->load / 2000U);`
However the result is always 0 because register LOAD cannot be read.
This PR allows to save the watchdog timeout value in a static variable. As it is done in Pico SDK, the stored timeout value is equal to the number of milliseconds x 1000 x 2 and eventually saturated to 0xFFFFFF.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->
These changes bring a duplication in the computation and storage of the watchdog timeout value.
The other option would be to modify the SDK adding a new function which returns the static timeout variable [load_value](https://github.com/raspberrypi/pico-sdk/blob/bfcbefafc5d2a210551a4d9d80b4303d4ae0adf7/src/rp2_common/hardware_watchdog/watchdog.c#L23).

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
#include "mbed.h"
#include "Watchdog.h"

mbed::Watchdog &watchdog = mbed::Watchdog::get_instance();

void setup() {

  Serial.begin(115200);
  while(!Serial) {}

  Serial.print("Starting watchdog: ");
  while(!watchdog.start(5000));
  Serial.println("OK!");

  watchdog.kick();

  Serial.print("Timeout: ");
  Serial.println(watchdog.get_timeout());

}

void loop() {
  watchdog.kick();
}
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
