### PR TITLE
PWM resume(): set period before duty cycle

### DIFF
--- a/drivers/source/PwmOut.cpp
+++ b/drivers/source/PwmOut.cpp
@@ -137,8 +137,8 @@ void PwmOut::resume()
     core_util_critical_section_enter();
     if (!_initialized) {
         PwmOut::init();
-        PwmOut::write(_duty_cycle);
         PwmOut::period_us(_period_us);
+        PwmOut::write(_duty_cycle);
     }
     core_util_critical_section_exit();
 }


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->
This PR fixes [issue #394](https://github.com/arduino/ArduinoCore-mbed/issues/394). The `resume()` function was writing the duty cycle before setting the period.
When `PwmOut::write(_duty_cycle)` is called, the PWM is enabled. But if the period is not set before, the PWM will be started with a period = 0.
To solve this, period must be set before duty cycle.

PR tested on: 
- [x] Nano RP2040 Connect
- [x] Portenta H7
- [x] Nano 33 BLE

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR
    

    #include "mbed.h"
    
    mbed::PwmOut sPwmOut(digitalPinToPinName(4));
    
    void setup() {
      Serial.begin(115200);
      while(!Serial) {}
        Serial.println("Start");
        sPwmOut.period_us(26);  // 26.315 for 38 kHz
        sPwmOut.pulsewidth_us(13);
        Serial.println("PWM set");
        delay(5000);
        
        for (int i = 0; i < 4; ++i) {
            delay(2000);
            sPwmOut.suspend();
            Serial.println("After suspend");
            delay(2000);
            sPwmOut.resume();
            Serial.println("After resume");
        }
    
        //Change duty cycle = 75%
        sPwmOut.pulsewidth_us(20);
        
    }
    
    void loop() {
    }

    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
