### PR TITLE
added API to set Modem's bands

### DIFF
--- a/connectivity/cellular/include/cellular/framework/API/CellularContext.h
+++ b/connectivity/cellular/include/cellular/framework/API/CellularContext.h
@@ -35,6 +35,24 @@ enum RadioAccessTechnologyType {
     CATNB = 8
 };
 
+enum FrequencyBand {
+    BAND_1 = 0x01,
+    BAND_2 = 0x02,
+    BAND_3 = 0x04,
+    BAND_4 = 0x08,
+    BAND_5 = 0x10,
+    BAND_8 = 0x80,
+    BAND_12 = 0x800,
+    BAND_13 = 0x1000,
+    BAND_18 = 0x20000,
+    BAND_19 = 0x40000,
+    BAND_20 = 0x80000,
+    BAND_25 = 0x1000000,
+    BAND_26 = 0x2000000,
+    BAND_28 = 0x8000000
+};
+
+
 namespace mbed {
 
 /**
@@ -160,6 +178,7 @@ public: // from NetworkInterface
                                   const char *pwd = 0) = 0;
     virtual void set_credentials(const char *apn, const char *uname = 0, const char *pwd = 0) = 0;
     virtual void set_access_technology(RadioAccessTechnologyType rat = CATM1) = 0;
+    virtual void set_band(FrequencyBand band = BAND_20) = 0;
     virtual bool is_connected() = 0;
 
     /** Same as NetworkInterface::get_default_instance()

--- a/connectivity/cellular/include/cellular/framework/AT/AT_CellularContext.h
+++ b/connectivity/cellular/include/cellular/framework/AT/AT_CellularContext.h
@@ -48,6 +48,7 @@ public:
                                   const char *pwd = 0);
     virtual void set_credentials(const char *apn, const char *uname = 0, const char *pwd = 0);
     virtual void set_access_technology(RadioAccessTechnologyType rat = CATM1);
+    virtual void set_band(FrequencyBand band = BAND_20);
 
 // from CellularContext
     virtual nsapi_error_t get_pdpcontext_params(pdpContextList_t &params_list);
@@ -135,6 +136,7 @@ private:
     PinName _dcd_pin;
     bool _active_high;
     RadioAccessTechnologyType _rat;
+    FrequencyBand _band;
 
 protected:
     char _found_apn[MAX_APN_LENGTH];


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

**Description of the the change:**
Added bands selection support on AT_CellularContext and CellularContext,

**Why the change is needed** 
required to allows CAt M1's TX68-w to support different band in accord with the customer Regios's requirements 
<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    


### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [X] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->
on my side the test went fine, waiting for third part test
<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
