### PR TITLE
lwipstack mbed_lib.json "socket-max":8 for Arduinos

### DIFF
--- a/connectivity/lwipstack/mbed_lib.json
+++ b/connectivity/lwipstack/mbed_lib.json
@@ -223,16 +223,32 @@
             "mem-size": 36560
         },
         "PORTENTA_H7": {
-            "mem-size": 16000
+            "mem-size": 16000,
+            "socket-max":8
         },
         "NICLA_VISION": {
-            "mem-size": 16000
+            "mem-size": 16000,
+            "socket-max":8
         },
         "OPTA": {
-            "mem-size": 16000
+            "mem-size": 16000,
+            "socket-max":8
         },
         "GIGA": {
-            "mem-size": 16000
+            "mem-size": 16000,
+            "socket-max":8
+        },
+        "ARDUINO_NANO33BLE": {
+            "mem-size": 3200,
+            "socket-max":8
+        },
+        "RASPBERRY_PI_PICO": {
+            "mem-size": 3200,
+            "socket-max":8
+        },
+        "NANO_RP2040_CONNECT": {
+            "mem-size": 3200,
+            "socket-max":8
         },
         "FVP_MPS2_M3": {
             "mem-size": 36560


### PR DESCRIPTION
lwipstack's mbed_lib.json rise "socket-max" to 8 for Arduinos (default is 4) and more mem-size for Nano boards and RP2040 Pico

the socket-max includes server(s) so 4 is too little. esp8266 has 5, but servers don't count. the classic Ethernet library has 8 sockets with W5000.

the Nano boards and RP2040 Pico can be used with Arduino Mbed platform's networking with my W5500-EMAC, ENC28J60-EMAC and ESPHost-EMAC libraries. with the 1600 bytes default mem-size lwip is unable to handle TCP/IP traffic.

